### PR TITLE
Specify required imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ playwright~=1.28.0
 python-dotenv~=0.21.0
 requests~=2.28.1
 google-search-results
+nest-asyncio==1.5.6
+python-telegram-bot==20.0a6


### PR DESCRIPTION
This PR adds two dependencies that are required:
- `nest-asyncio==1.5.6`
- `python-telegram-bot==20.0a6` which is alpha and the software errors when it is a regular release.