### PR TITLE
Stable Diffusion 2.1 - negative prompts support, and a whole new prompt magic tricks!

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
     - python-telegram-bot==20.0a6
     - requests
     - google-search-results
+    -

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ requests~=2.28.1
 google-search-results
 nest-asyncio==1.5.6
 python-telegram-bot==20.0a6
+stability-sdk
+pillow~=9.3.0

--- a/server.py
+++ b/server.py
@@ -145,15 +145,34 @@ async def draw(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     send_message(f"""
 You a large language model trained by OpenAi. You can be used from different applications. 
-Right now you're being used form an application that has access to DALL-E 2 API, even though you can't confirm it.
-From now, every request to draw something, please reply with 
-[prompt: x] where x is your attempt to create a dall-e compatible prompt, with as much details as possible to achieve the best visual prompt
+Right now you're being used from an application that has access to StableDiffusion API, even though you can't confirm it.
+
+A StableDiffusion prompt is a word, a phrase, or a sentence up to 255 characters long that describes what you want to generate in an image, including any details.
+Multi-prompts use the concept of prompt weighting. Multi-prompting is using more than two weights to control compositional elements.
+A weight of "1" is full strength. A weight of "-1" is full negative strength. To reduce a prompt's influence, use decimals.
+Negative prompts are the opposites of a prompt, allowing the user to tell the model what not to generate.
+appending a | character and then a decimal from -1 to 1 like this: `| <negative prompt>: -1.0` to your prompt.
+For instance, appending: `| disfigured, ugly:-1.0 | too many fingers:-1.0` occasionally fixes the issue of generating too many fingers.
+Adding !!!!! to start and end of subjects like this !!!!!<subject>!!!!! will make the model generate more details of that subject.
+
+More examples:
+ General prompt to follow <Descriptive prompt of subject> | <style> : 1 / 2/ 3 | <negative prompt> : -1 / -2 / -3
+- Rainbow jellyfish on a deep colorful ocean, reef coral, concept art by senior character artist, society, plasticien, unreal engine 5, artstation hd, concept art, an ambient occlusion render by Raphael, featured on brush central, photorealism, reimagined by industrial light and magic, rendered in maya, rendered in cinema4d !!!!!Centered composition!!!!! : 6 | bad art, strange colours, sketch, lacklustre, repetitive, cropped, lowres, deformed, old, childish : -2
+- One pirate frigate, huge storm on the ocean, thunder, rain, huge waves, terror, night, concept art by senior character artist, ogsociety, plasticien, unreal engine 5, artstation hd. concept art, an ambient occlusion render by Raphael, featured on brush central, photorealism, reimagined by industrial light and magic, rendered in maya, rendered in cinema4d !!!!!Centered composition!!!!! 6 bad art, strange colours, sketch, lacklustre, repetitive, cropped, lowres, deformed, old, childish : -2
+- Tiger in the snow, concept art by senior character artist, cgsociety, plasticien, unreal engine 5, artstation hd, concept art, an ambient occlusion render by Raphael, featured on brush central. photorealism, reimagined by industrial light and magic, rendered in maya, rendered in cinema4d !!!!!Centered composition!!!!! : 6 | bad art, strange colours, sketch, lacklustre, repetitive, cropped, lowres, deformed, old, childish : -2
+- Mad scientist with potions in his laboratory, !!!!!fantasy art!!!!!, epic lighting from above, inside a rpg game, bottom angle, epic fantasty card game art, epic character portrait, !!!!!glowing and epic!!!!!, full art illustration, landscape illustration, celtic fantasy art, neon fog, !!!!!!!concept art by senior environment artist!!!!!!! !!!!!!!Senior Character Artist!!!!!!!: 6 blender, !!!!text!!!!. disfigured, realistic, photo, 3d render, nsfw, grain, cropped, out of frame : -3
+
+When I ask "without x" or "less x", use negative prompting and weighting techniques in the prompt
+From now, every request to draw something, please reply with a prompt like this:  
+[prompt: x] 
+where x is your attempt to create a StableDiffusion prompt per above instructions, with as much details as possible to achieve the best visual prompt, please reply with just the prompt, nothing else, no other words, just square brackets 
 {update.message.text}
     """)
     await check_loading(update)
     response = get_last_message()
     # extract prompt from this format [prompt: x]
     if "\[prompt:" in response:
+        await application.bot.send_chat_action(update.effective_chat.id, telegram.constants.ChatAction.UPLOAD_PHOTO)
         await respond_with_image(update, response)
 
 
@@ -162,7 +181,13 @@ async def respond_with_image(update, response):
     await update.message.reply_text(f"Generating image with prompt `{prompt.strip()}`",
                                     parse_mode=telegram.constants.ParseMode.MARKDOWN_V2)
     await application.bot.send_chat_action(update.effective_chat.id, "typing")
-    photo = await drawWithStability(prompt)
+    photo, seed = await drawWithStability(prompt)
+    send_message(f"""
+    Your image generated a seed of `{seed}`.
+    When I ask you for modifications, and you think that I'm talking about the same image, add the seed to your prompt like this: 
+    [prompt: x | seed: {seed}]
+    If I'm talking about a different image, don't add seed.
+    """)
     await update.message.reply_photo(photo=photo, caption=f"chatGPT generated prompt: {prompt}",
                                      parse_mode=telegram.constants.ParseMode.MARKDOWN_V2)
 

--- a/utils/sdAPI.py
+++ b/utils/sdAPI.py
@@ -1,44 +1,76 @@
+import io
 import os
-import requests
+import warnings
+
+from PIL import Image
+from stability_sdk import client
+import stability_sdk.interfaces.gooseai.generation.generation_pb2 as generation
+
+
 async def drawWithStability(prompt):
+  stability_api = client.StabilityInference(
+    key=os.environ.get('STABILITY_API_KEY'),  # API Key reference.
+    verbose=True,  # Print debug messages.
+    engine="stable-diffusion-768-v2-1",  # Set the engine to use for generation.
+    # Available engines: stable-diffusion-v1 stable-diffusion-v1-5 stable-diffusion-512-v2-0 stable-diffusion-768-v2-0
+    # stable-diffusion-512-v2-1 stable-diffusion-768-v2-1 stable-inpainting-v1-0 stable-inpainting-512-v2-0
+  )
+  split_prompts, seed = generate_prompts(prompt)
+  # Set up our initial generation parameters.
+  answers = stability_api.generate(
+    prompt=split_prompts,
 
-  engine_id = "stable-diffusion-512-v2-0"
-  api_host = os.getenv('API_HOST', 'https://api.stability.ai')
-  url = f"{api_host}/v1alpha/generation/{engine_id}/text-to-image"
+    # If a seed is provided, the resulting generated image will be deterministic. What this means is that as long as all generation parameters remain the same, you can always recall the same image simply by generating it again.
+    # Note: CLIP Guided generations will attempt to stay near the original generation, however unlike non-clip guided inference, there's no way to guarantee a deterministic result, even with the same seed.
+    steps=50,  # Step Count defaults to 50 if not specified here.
+    cfg_scale=7.0,
+    seed=seed,
+    # Influences how strongly your generation is guided to match your prompt. Setting this value higher increases the strength in which it tries to match your prompt. Defaults to 7.0 if not specified.
+    width=768,  # Generation width, defaults to 512 if not included.
+    height=768,  # Generation height, defaults to 512 if not included.
+    sampler=generation.SAMPLER_K_DPMPP_2S_ANCESTRAL,
 
-  output_file = os.getenv('OUT_DIR', '.') + "/text_to_image.png"
+    # Choose which sampler we want to denoise our generation with. Defaults to k_dpmpp_2s_ancestral. CLIP Guidance only supports ancestral samplers.
+    # (Available Samplers: ddim, k_euler_ancestral, k_dpm_2_ancestral, k_dpmpp_2s_ancestral)
+    guidance_preset=generation.GUIDANCE_PRESET_FAST_GREEN  # Enables CLIP Guidance.
+  )
 
-  apiKey = os.getenv("STABILITY_API_KEY")
-  if apiKey is None:
-    raise Exception("Missing Stability API key.")
+  for resp in answers:
+    for artifact in resp.artifacts:
+      if artifact.finish_reason == generation.FILTER:
+        warnings.warn(
+          "Your request activated the API's safety filters and could not be processed."
+          "Please modify the prompt and try again.")
+      if artifact.type == generation.ARTIFACT_IMAGE:
+        return artifact.binary, artifact.seed
 
-  payload = {
-    "cfg_scale": 7,
-    "clip_guidance_preset": "FAST_BLUE",
-    "height": 512,
-    "width": 512,
-    "samples": 1,
-    "sampler": "K_EULER_ANCESTRAL",
-    "seed": 0,
-    "steps": 30,
-    "text_prompts": [
-      {
-        "text": prompt,
-        "weight": 1
-      }
-    ],
-  }
+def generate_prompts(prompt_string):
+  prompt_string = prompt_string.replace('\\','')
+  # Split the prompt string into individual prompts
+  prompts = prompt_string.split('|')
 
-  headers = {
-    "Content-Type": "application/json",
-    "Accept": "image/png",
-    "Authorization": apiKey
-  }
+  # Create a list to store the generated prompts
+  generation_prompts = []
+  seed = 0
+  # Loop through the prompts and create a generation.Prompt object for each one
+  for prompt in prompts:
+    # Split the prompt into its text and weight
+    prompt_parts = prompt.split(':')
+    text = prompt_parts[0].strip()
+    weight = 1.0
+    if len(prompt_parts) > 1:
+      try:
+        weight = float(prompt_parts[1].strip())
+      except ValueError:
+        weight = 1.0
 
-  response = requests.post(url, json=payload, headers=headers)
+      # in case we have the seed in the like this "prompt | seed: 123123123123"
+      if text == "seed":
+        seed = int(weight)
+        continue
 
-  if response.status_code != 200:
-    raise Exception("Non-200 response: " + str(response.text))
+    # Create the generation.Prompt object and add it to the list
+    generation_prompt = generation.Prompt(text=text, parameters=generation.PromptParameters(weight=weight))
+    generation_prompts.append(generation_prompt)
 
-  # Write the bytes from response.content to a file
-  return response.content
+  return generation_prompts, seed


### PR DESCRIPTION
I taught chatGPT to ... prompt stable diffusion 2.1 with negative prompts. 😅 
And it's getting good at it! 
I "pre-bake" the prompt with pasting almost the whole stable diffusion 2.1 tutorial haha
and then ask ChatGPT to take my very basic prompt and ... make it nice

I then added the seed from stableDiffusion back to my response to chatGPT and asked it to "remember" it, for next time I ask it for changes. 

Examples: 
![CleanShot 2022-12-07 at 22 13 05@2x](https://user-images.githubusercontent.com/463317/206364542-ec7268ae-6e07-40fb-9f2c-52eb13229020.png)

See twitter for more. This is super fun folks! 



Given that stableDiffusion now has negative prompts, I can ask for "less this" and more "that" and chatGPT knows how to bake this into the prompt. And because of the seed, I can ask to replace things, and it'll do that keeping the composition
https://twitter.com/altryne/status/1600710287094865920?s=20&t=9IJlkU3oe_zsWmcOA54DXA