### PR TITLE
https://github.com/altryne/chatGPT-telegram-bot/issues/48

### DIFF
--- a/server.py
+++ b/server.py
@@ -89,7 +89,7 @@ class AtrributeError:
 
 def get_last_message():
     """Get the latest message"""
-    page_elements = PAGE.query_selector_all("div[class*='request-']")
+    page_elements = PAGE.query_selector_all("div[class*='lg:w-[calc(100%-115px)]']")
     last_element = page_elements[-1]
     prose = last_element
     try:


### PR DESCRIPTION
tôi đã cài đặt các gói môi trường nhưng khi tôi chạy thì nhận được lỗi này 

Please log in to OpenAI Chat
Press enter when you're done
Traceback (most recent call last):
  File "/home/ai_car/chatbot/chatGPT-telegram-bot-altryne/server.py", line 307, in <module>
    start_browser()
  File "/home/ai_car/chatbot/chatGPT-telegram-bot-altryne/server.py", line 272, in start_browser
    PAGE.locator("button", has_text="Log in").click(timeout = 20000)
  File "/home/ai_car/anaconda3/envs/chat/lib/python3.10/site-packages/playwright/sync_api/_generated.py", line 13670, in click
    self._sync(
  File "/home/ai_car/anaconda3/envs/chat/lib/python3.10/site-packages/playwright/_impl/_sync_base.py", line 104, in _sync
    return task.result()
  File "/home/ai_car/anaconda3/envs/chat/lib/python3.10/asyncio/futures.py", line 201, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/home/ai_car/anaconda3/envs/chat/lib/python3.10/asyncio/tasks.py", line 232, in __step
    result = coro.send(None)
  File "/home/ai_car/anaconda3/envs/chat/lib/python3.10/site-packages/playwright/_impl/_locator.py", line 146, in click
    return await self._frame.click(self._selector, strict=True, **params)
  File "/home/ai_car/anaconda3/envs/chat/lib/python3.10/site-packages/playwright/_impl/_frame.py", line 489, in click
    await self._channel.send("click", locals_to_params(locals()))
  File "/home/ai_car/anaconda3/envs/chat/lib/python3.10/site-packages/playwright/_impl/_connection.py", line 44, in send
    return await self._connection.wrap_api_call(
  File "/home/ai_car/anaconda3/envs/chat/lib/python3.10/site-packages/playwright/_impl/_connection.py", line 419, in wrap_api_call
    return await cb()
  File "/home/ai_car/anaconda3/envs/chat/lib/python3.10/site-packages/playwright/_impl/_connection.py", line 79, in inner_send
    result = next(iter(done)).result()
  File "/home/ai_car/anaconda3/envs/chat/lib/python3.10/asyncio/futures.py", line 201, in result
    raise self._exception.with_traceback(self._exception_tb)
playwright._impl._api_types.TimeoutError: Timeout 20000ms exceeded.
=========================== logs ===========================
waiting for locator("button").filter(has_text="Log in")
============================================================